### PR TITLE
Remove unused ansible variables from documentation and fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,24 +106,6 @@ The [ITL](https://www.icinga.com/docs/icinga2/latest/doc/10-icinga-template-libr
 pre-configured check commands. This variable defines what to include. Defaults to
 `["itl", "plugins", "plugins-contrib", "manubulon", "windows-plugins", "nscp"]`
 
-#### Variable: `i2_const_plugindir`
-Set `PluginDir` constant. Defaults to `{{ i2_lib_dir }}/nagios/plugins`.
-
-#### Variable: `i2_const_manubulonplugindir`
-Set `ManubulonPluginDir` constant. Defaults to `{{ i2_lib_dir }}/nagios/plugins`.
-
-#### Variable: `i2_const_plugincontribdir`
-Set `PluginContribDir` constant. Defualts to `{{ i2_lib_dir }}/nagios/plugins`.
-
-#### Variable: `i2_const_nodename`
-Set `NodeName` constant. Defaults to `{{ ansible_fqdn }}`.
-
-#### Variable: `i2_const_zonename`
-Set `ZoneName` constant. Defaults to `{{ ansible_fqdn }}`.
-
-#### Variable: `i2_const_ticketsalt`
-Set `TicketSalt` constant. Empty by default.
-
 #### Variable: `i2_custom_constants`
 Add custom constants to `constants.conf`. Must be a dictionary. Defaults to: `{}`
 
@@ -142,7 +124,7 @@ Default values of `i2_default_constants`:
 Example usage:
 ```yaml
   vars:
-    - i2_constants:
+    - i2_custom_constants:
         TicketSalt: "My ticket salt"
         Foo: "bar"
 ```

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,8 +18,6 @@ galaxy_info:
       versions:
         - 16.04
         - 18.04
-  categories:
-    - system
   galaxy_tags:
     - monitoring
     - icinga

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include OS specific vars
-  include_vars: "{{ansible_os_family}}.yml"
+  include_vars: "{{ ansible_os_family }}.yml"
   tags:
     - feature-handler
     - config


### PR DESCRIPTION
These constants are not used. This is now handled by the i2_custom_const variable
Fixes #35