### PR TITLE
Fix ansible lint issues

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,8 +18,6 @@ galaxy_info:
       versions:
         - 16.04
         - 18.04
-  categories:
-    - system
   galaxy_tags:
     - monitoring
     - icinga

--- a/tasks/icinga2-RedHat.yml
+++ b/tasks/icinga2-RedHat.yml
@@ -13,8 +13,8 @@
   become: True
   yum:
     name: epel-release
-    state: presen_package
-  when: i2_manage_repository
+    state: present
+  when: i2_manage_package
 
 - name: RedHat - Ensure icinga2 is installed
   become: yes

--- a/tasks/icinga2-RedHat.yml
+++ b/tasks/icinga2-RedHat.yml
@@ -9,6 +9,13 @@
     gpgcheck: yes
   when: i2_manage_repository
 
+- name: RedHat - Ensure EPEL is enabled
+  become: True
+  yum:
+    name: epel-release
+    state: presen_package
+  when: i2_manage_repository
+
 - name: RedHat - Ensure icinga2 is installed
   become: yes
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include OS specific vars
-  include_vars: "{{ansible_os_family}}.yml"
+  include_vars: "{{ ansible_os_family }}.yml"
   tags:
     - feature-handler
     - config

--- a/templates/feature-generic-template.conf.j2
+++ b/templates/feature-generic-template.conf.j2
@@ -1,7 +1,7 @@
 // {{ ansible_managed }}
 {% import 'object_attributes.j2' as attributes %}
 
-{% for object_name, params in item.value.iteritems() %}
+{% for object_name, params in item.value.items() %}
 object {{ item.key }} "{{ object_name }}" {
    {{ attributes.attrs(params) -}}
 }

--- a/templates/object_attributes.j2
+++ b/templates/object_attributes.j2
@@ -1,5 +1,5 @@
 {% macro attrs(map, exclude=[]) %}
-{% for k, v in map.iteritems() %}
+{% for k, v in map.items() %}
 {%- if v is mapping %}
 {{ mapdict(k,v) | indent(width=2)}}
 {%- else %}
@@ -10,7 +10,7 @@
 
 {% macro mapdict(key,dictionary) %}
 {{ key }} = {
-{% for i, w in dictionary.iteritems() %}
+{% for i, w in dictionary.items() %}
 {%- if w is mapping %}
 {{ mapdict(i,w) | indent(width=2)}}
 {%- else %}


### PR DESCRIPTION
This PR fixes some small ansible-lint warnings.
It also adds Python 3 compatibility and installs the EPEL repository which is needed for Icinga 2.11
This should fix the Travis build