### PR TITLE
removed and updated ansible eol versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ script:
   - molecule test
 matrix:
   include:
-    - env: ANSIBLE_VERSION="2.5.9"
-    - env: ANSIBLE_VERSION="2.6.5"
-    - env: ANSIBLE_VERSION="2.7.0"
-    - env: ANSIBLE_VERSION="2.7.5"
+    - env: ANSIBLE_VERSION="2.7.14"
+    - env: ANSIBLE_VERSION="2.8.5"
+    - env: ANSIBLE_VERSION="2.9.0"
 branches:
   only:
     - master


### PR DESCRIPTION
Removed the EOL Versions of Ansible. To prepare for future changes as **with_items** iterations should be replaced with **loop**. 

Ansible 2.9.0 doesn't complain in the local molecule environment 


How should versions be handled? Only Major Versions or also the Minors? 
I choose for each the latest version