### PR TITLE
Epel package managing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Ansible role to install and configure [Icinga 2](https://www.icinga.com/products/icinga-2/).
 
-# This Role is in development stage 
+# This Role is in development stage
 
 ## Setup
 
@@ -52,6 +52,7 @@ You may choose to use your own or the systems default repositories. Repository m
 - [**Variables**](#variables)
     - [Variable: i2_manage_repository](#variable-i2_manage_repository)
     - [Variable: i2_manage_package](#variable-i2_manage_package)
+    - [Variable: i2_manage_package](#variable-i2_manage_epel)
     - [Variable: i2_manage_service](#variable-i2_manage_service)
     - [Variable: i2_apt_key](#variable-i2_apt_key)
     - [Variable: i2_apt_url](#variable-i2_apt_url)
@@ -76,6 +77,9 @@ Whether to add the official [Icinga Repository](https://packages.icinga.com/) to
 
 #### Variable: `i2_manage_package`
 Whether to install packages or not. Defaults to `true`.
+
+#### Variable: `i2_manage_epel`
+Whether to install the EPEL release package. Defaults to `true`.
 
 #### Variable: `i2_manage_service`
 Whether to start, restart and reload the Icinga 2 on changes or not. Defaults to `true`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ i2_yum_key: "https://packages.icinga.com/icinga.key"
 i2_yum_url: "http://packages.icinga.com/epel/$releasever/release/"
 i2_manage_package: true
 i2_manage_service: true
+i2_manage_epel: true
 i2_remove_unmanaged_features: false
 i2_confd:
   - "conf.d"

--- a/tasks/icinga2-RedHat.yml
+++ b/tasks/icinga2-RedHat.yml
@@ -10,11 +10,11 @@
   when: i2_manage_repository
 
 - name: RedHat - Ensure EPEL is enabled
-  become: True
+  become: yes
   yum:
     name: epel-release
     state: present
-  when: i2_manage_package
+  when: i2_manage_epel
 
 - name: RedHat - Ensure icinga2 is installed
   become: yes


### PR DESCRIPTION
We should not force the user to use the EPEL repo and when he disables the management of epel icinga2 doesn't get installed. 

So added the i2_manage_epel switch to give the choice whether he uses the epel within the role or he's managing his own mirror in an external role